### PR TITLE
Patch files that use empty GroupType and GraphType structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ This will generate the API v1 client files under `output/jcapiv1`
 
 Once you are satisfied with the generated API client, you can replace the existing files under the `jcapiv1` and `jcapiv2` folders with your generated files.
 
+There currently seems to be a bug with swagger-codegen where it fails to generate certain enum structs correctly (namely GraphType and GroupType). Make sure to run the following commands in order to replace these empty structs with just strings:
+```
+sed -e ':a' -e 'N' -e '$!ba' -e 's/struct {\n}/string/g' jcapiv2/group_type.go > tmp && mv tmp jcapiv2/group_type.go
+sed -e ':a' -e 'N' -e '$!ba' -e 's/struct {\n}/string/g' jcapiv2/graph_type.go > tmp && mv tmp jcapiv2/graph_type.go
+```
+
 #### Usage Examples
 
 ```

--- a/jcapiv2/graph_type.go
+++ b/jcapiv2/graph_type.go
@@ -11,5 +11,4 @@
 package jcapiv2
 
 // The graph type.
-type GraphType struct {
-}
+type GraphType string

--- a/jcapiv2/group_type.go
+++ b/jcapiv2/group_type.go
@@ -11,5 +11,4 @@
 package jcapiv2
 
 // The group type.
-type GroupType struct {
-}
+type GroupType string


### PR DESCRIPTION
There seems to be a bug with swagger-codegen where certain enums (GraphType and GroupType) are generated as empty structures.
I'm not entirely sure what is going on here. This will need further investigation. I know this isn't ideal but for now I have patched the affected files and edited the README with commands to run the patch so that the next person running swagger-codegen can get to the same state.