### PR TITLE
Restore docker files that were removed by mistake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.11.4
+
+WORKDIR /go/src/github.com/TheJumpCloud/jcapi-go
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  swagger-codegen:
+    image: jimschubert/swagger-codegen-cli:2.3.1
+    volumes:
+      - ./input:/swagger-api/yaml # volume for input yaml files
+      - ./output:/swagger-api/out # volume for generated files
+      - .:/config # volume for config files
+  tools:
+    build: .
+    volumes:
+      - .:/go/src/github.com/TheJumpCloud/jcapi-go
+


### PR DESCRIPTION
We mistakenly removed the docker and docker compose files in the last release. This change restores them.